### PR TITLE
User 객체 및 서비스, 접근제어, 접근 예시

### DIFF
--- a/src/main/java/com/estsoft/estsoft2ndproject/config/WebSecurityConfig.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/config/WebSecurityConfig.java
@@ -12,11 +12,17 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.estsoft.estsoft2ndproject.custonException.AdditionalInformationRequireException;
+import com.estsoft.estsoft2ndproject.exception.CustomAccessDeniedHandler;
 import com.estsoft.estsoft2ndproject.service.UserService;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class WebSecurityConfig {
+	private final CustomAccessDeniedHandler accessDeniedHandler;
+
 	@Bean
 	public SecurityFilterChain sercurityFilterChain(HttpSecurity http, UserService userService) throws Exception {
 		return http
@@ -26,7 +32,7 @@ public class WebSecurityConfig {
 				.requestMatchers("/css/**", "/js/**", "/images/**", "/webjars/**", "/favicon.*").permitAll()
 				.requestMatchers("/admin/**").hasAuthority("관리자")
 				.requestMatchers("/member/login").permitAll()
-				.requestMatchers("/**").hasAnyAuthority("씨앗", "새싹", "묘목", "성목", "고목", "관리자")
+				// .requestMatchers("/**").hasAnyAuthority("씨앗", "새싹", "묘목", "성목", "고목", "관리자")
 				.anyRequest().permitAll()
 			)
 			.oauth2Login(oauth2 -> oauth2
@@ -52,6 +58,8 @@ public class WebSecurityConfig {
 				.invalidateHttpSession(true)
 				.deleteCookies("JSESSIONID")
 			)
+			.exceptionHandling(handling -> handling
+				.accessDeniedHandler(accessDeniedHandler))
 			.csrf(csrf -> csrf.disable())
 			.build();
 	}

--- a/src/main/java/com/estsoft/estsoft2ndproject/config/WebSecurityConfig.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/config/WebSecurityConfig.java
@@ -22,11 +22,15 @@ public class WebSecurityConfig {
 		return http
 			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.authorizeHttpRequests(custom -> custom
-				.requestMatchers("/**").permitAll()
-				.requestMatchers("/admin/**").hasAuthority("관리자").anyRequest().authenticated()
+				.requestMatchers("/").permitAll()
+				.requestMatchers("/css/**", "/js/**", "/images/**", "/webjars/**", "/favicon.*").permitAll()
+				.requestMatchers("/admin/**").hasAuthority("관리자")
+				.requestMatchers("/member/login").permitAll()
+				.requestMatchers("/**").hasAnyAuthority("씨앗", "새싹", "묘목", "성목", "고목", "관리자")
+				.anyRequest().permitAll()
 			)
 			.oauth2Login(oauth2 -> oauth2
-				.loginPage("/member/login")
+				.loginPage("/")
 				.defaultSuccessUrl("/", true)
 				.userInfoEndpoint(endpoint -> endpoint.userService(userService))
 				.failureHandler(((request, response, exception) -> {

--- a/src/main/java/com/estsoft/estsoft2ndproject/controller/api/CommentApiController.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/controller/api/CommentApiController.java
@@ -88,14 +88,14 @@ public class CommentApiController {
 	}
 
 	@GetMapping("/{postId}/comments")
-	public String commentsTest(Model model, @PathVariable(name = "postId") Long postId, @AuthenticationPrincipal OAuth2User oAuth2User) {
+	public String commentsTest(Model model, @PathVariable(name = "postId") Long postId, @AuthenticationPrincipal CustomUserDetails oAuth2User) {
 		List<CommentListResponseDTO> commentList = commentService.getCommentsByPostId(postId)
 			.stream()
 			.map(CommentListResponseDTO::new)
 			.sorted(Comparator.comparing(CommentListResponseDTO::getCreatedAt))
 			.toList();
 
-		Long userId = userService.getUserId(oAuth2User);
+		Long userId = oAuth2User.getUser().getUserId();
 
 		model.addAttribute("comments", commentList);
 		model.addAttribute("userId", userId);

--- a/src/main/java/com/estsoft/estsoft2ndproject/controller/api/CommentApiController.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/controller/api/CommentApiController.java
@@ -21,6 +21,7 @@ import com.estsoft.estsoft2ndproject.domain.Comment;
 import com.estsoft.estsoft2ndproject.domain.dto.comment.CommentListResponseDTO;
 import com.estsoft.estsoft2ndproject.domain.dto.comment.CommentRequestDTO;
 import com.estsoft.estsoft2ndproject.domain.dto.comment.CommentResponseDTO;
+import com.estsoft.estsoft2ndproject.domain.dto.user.CustomUserDetails;
 import com.estsoft.estsoft2ndproject.service.CommentService;
 import com.estsoft.estsoft2ndproject.service.UserService;
 
@@ -47,7 +48,7 @@ public class CommentApiController {
 	@PostMapping("/{postId}/comment")
 	public ResponseEntity<CommentResponseDTO> createComment(@RequestBody CommentRequestDTO commentRequestDTO,
 		@PathVariable(name = "postId") Long postId,
-		@AuthenticationPrincipal OAuth2User oAuth2User) {
+		@AuthenticationPrincipal CustomUserDetails oAuth2User) {
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(commentService.createComment(commentRequestDTO, postId, oAuth2User).convert());
@@ -57,7 +58,7 @@ public class CommentApiController {
 	public ResponseEntity<CommentResponseDTO> createCommentWithParent(@RequestBody CommentRequestDTO commentRequestDTO,
 		@PathVariable(name = "postId") Long postId,
 		@PathVariable(name = "commentId") Long commentId,
-		@AuthenticationPrincipal OAuth2User oAuth2User) {
+		@AuthenticationPrincipal CustomUserDetails oAuth2User) {
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(commentService.createComment(commentRequestDTO, postId, commentId, oAuth2User).convert());

--- a/src/main/java/com/estsoft/estsoft2ndproject/controller/api/UserController.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/controller/api/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.estsoft.estsoft2ndproject.domain.dto.user.CustomUserDetails;
 import com.estsoft.estsoft2ndproject.domain.dto.user.RegisterRequestDTO;
 import com.estsoft.estsoft2ndproject.service.UserService;
 
@@ -68,7 +69,7 @@ public class UserController {
 	}
 
 	@GetMapping("/member/cancellation")
-	public ResponseEntity<String> delete(@AuthenticationPrincipal OAuth2User oAuth2User, HttpServletRequest request) {
+	public ResponseEntity<String> delete(@AuthenticationPrincipal CustomUserDetails oAuth2User, HttpServletRequest request) {
 		HttpSession session = request.getSession();
 		session.invalidate();
 

--- a/src/main/java/com/estsoft/estsoft2ndproject/controller/main/CustomErrorController.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/controller/main/CustomErrorController.java
@@ -1,0 +1,13 @@
+package com.estsoft.estsoft2ndproject.controller.main;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class CustomErrorController implements ErrorController {
+	@GetMapping("/error")
+	public String handleError() {
+		return "redirect:/";
+	}
+}

--- a/src/main/java/com/estsoft/estsoft2ndproject/controller/main/PageController.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/controller/main/PageController.java
@@ -1,39 +1,35 @@
 package com.estsoft.estsoft2ndproject.controller.main;
 
 import com.estsoft.estsoft2ndproject.domain.SubMenu;
+import com.estsoft.estsoft2ndproject.domain.User;
+import com.estsoft.estsoft2ndproject.domain.dto.user.CustomUserDetails;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 @Controller
 public class PageController {
 
-	@GetMapping("/index")
-	public String menuPage(Model model) {
-		List<SubMenu> subMenus;
+	@GetMapping("/")
+	public String menuPage(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		List<SubMenu> subMenus = new ArrayList<>();
+		subMenus.add(new SubMenu("카테고리", Arrays.asList("취미1", "취미2")));
+		subMenus.add(new SubMenu("챌린지", null));
+		subMenus.add(new SubMenu("지역 친목 게시판", Arrays.asList("강원도", "경기도", "서울특별시")));
+		subMenus.add(new SubMenu("마이페이지", Arrays.asList("프로필 설정", "내 활동 보기")));
 
-		String level = "관리자";
+		if (userDetails != null) {
+			User user = userDetails.getUser();
 
-		// 조건에 따라 서브메뉴 구성
-		if ("관리자".equals(level)) {
-			subMenus = Arrays.asList(
-				new SubMenu("카테고리", Arrays.asList("취미1", "취미2")),
-				new SubMenu("챌린지", Arrays.asList("챌린지 아이템 1", "특별 챌린지")),
-				new SubMenu("지역 친목 게시판", Arrays.asList("강원도", "경기도", "서울특별시")),
-				new SubMenu("마이페이지", Arrays.asList("프로필 설정", "내 활동 보기")),
-				new SubMenu("관리자 메뉴", Arrays.asList("사용자 관리", "사이트 설정"))
-			);
-		} else {
-			subMenus = Arrays.asList(
-				new SubMenu("카테고리", Arrays.asList("취미1", "취미2")),
-				new SubMenu("챌린지", Arrays.asList("챌린지 아이템 1")),
-				new SubMenu("지역 친목 게시판", Arrays.asList("강원도", "경기도", "서울특별시")),
-				new SubMenu("마이페이지", Arrays.asList("프로필 설정", "내 활동 보기"))
-			);
+			if (user.getLevel().equals("관리자")) {
+				subMenus.add(3, new SubMenu("관리자 메뉴", null));
+			}
 		}
 
 		model.addAttribute("subMenus", subMenus);

--- a/src/main/java/com/estsoft/estsoft2ndproject/domain/dto/user/CustomUserDetails.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/domain/dto/user/CustomUserDetails.java
@@ -1,0 +1,70 @@
+package com.estsoft.estsoft2ndproject.domain.dto.user;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.estsoft.estsoft2ndproject.domain.User;
+
+import lombok.Getter;
+
+@Getter
+public class CustomUserDetails implements OAuth2User, UserDetails {
+	private final User user;
+	private final Map<String, Object> attributes;
+
+	public CustomUserDetails(User user, Map<String, Object> attributes) {
+		this.user = user;
+		this.attributes = attributes;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority(user.getLevel()));
+	}
+
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return user.getIsActive();
+	}
+
+	@Override
+	public String getName() {
+		return user.getEmail();
+	}
+}

--- a/src/main/java/com/estsoft/estsoft2ndproject/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package com.estsoft.estsoft2ndproject.exception;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write("{\"message\": \"접근 권한이 없습니다.\"}");
+	}
+}

--- a/src/main/java/com/estsoft/estsoft2ndproject/service/CommentService.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/service/CommentService.java
@@ -10,6 +10,7 @@ import com.estsoft.estsoft2ndproject.domain.Comment;
 import com.estsoft.estsoft2ndproject.domain.Post;
 import com.estsoft.estsoft2ndproject.domain.User;
 import com.estsoft.estsoft2ndproject.domain.dto.comment.CommentRequestDTO;
+import com.estsoft.estsoft2ndproject.domain.dto.user.CustomUserDetails;
 import com.estsoft.estsoft2ndproject.exception.PostNotFoundException;
 import com.estsoft.estsoft2ndproject.repository.CommentRepository;
 import com.estsoft.estsoft2ndproject.repository.PostRepository;
@@ -33,17 +34,17 @@ public class CommentService {
 	}
 
 	@Transactional
-	public Comment createComment(CommentRequestDTO commentRequestDTO, Long postId, OAuth2User oAuth2User) {
+	public Comment createComment(CommentRequestDTO commentRequestDTO, Long postId, CustomUserDetails oAuth2User) {
 		Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(postId));
-		User user = userRepository.findByPii(oAuth2User.getName());
+		User user = oAuth2User.getUser();
 
 		return commentRepository.save(commentRequestDTO.toEntity(post, user));
 	}
 
 	@Transactional
-	public Comment createComment(CommentRequestDTO commentRequestDTO, Long postId, Long commentId, OAuth2User oAuth2User) {
+	public Comment createComment(CommentRequestDTO commentRequestDTO, Long postId, Long commentId, CustomUserDetails oAuth2User) {
 		Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(postId));
-		User user = userRepository.findByPii(oAuth2User.getName());
+		User user = oAuth2User.getUser();
 		Comment parentComment = commentRepository.findById(commentId).orElse(null);
 
 		return commentRepository.save(commentRequestDTO.toEntity(post, user, parentComment));

--- a/src/main/java/com/estsoft/estsoft2ndproject/service/UserService.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/service/UserService.java
@@ -145,16 +145,4 @@ public class UserService extends DefaultOAuth2UserService {
 
 		userRepository.save(userEntity);
 	}
-
-	public Long getUserId(OAuth2User oAuth2User) {
-		return userRepository.findByPii(oAuth2User.getName()).getUserId();
-	}
-
-	public User getUser(OAuth2User oAuth2User) {
-		return userRepository.findByPii(oAuth2User.getName());
-	}
-
-	public User getUserById(Long userId) {
-		return userRepository.findById(userId).orElse(null);
-	}
 }

--- a/src/main/java/com/estsoft/estsoft2ndproject/service/UserService.java
+++ b/src/main/java/com/estsoft/estsoft2ndproject/service/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.web.client.RestTemplate;
 
 import com.estsoft.estsoft2ndproject.custonException.AdditionalInformationRequireException;
 import com.estsoft.estsoft2ndproject.domain.User;
+import com.estsoft.estsoft2ndproject.domain.dto.user.CustomUserDetails;
 import com.estsoft.estsoft2ndproject.repository.UserRepository;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -117,7 +118,8 @@ public class UserService extends DefaultOAuth2UserService {
 
 		userRepository.save(userEntity);
 
-		return new DefaultOAuth2User(authorities, oAuth2User.getAttributes(), usernameAttributeName);
+		// return new DefaultOAuth2User(authorities, oAuth2User.getAttributes(), usernameAttributeName);
+		return new CustomUserDetails(userEntity, oAuth2User.getAttributes());
 	}
 
 	public void logoutFromKakao(String accessToken) {
@@ -134,8 +136,8 @@ public class UserService extends DefaultOAuth2UserService {
 	}
 
 	@Transactional
-	public void deleteUser(OAuth2User oAuth2User) {
-		User userEntity = userRepository.findByPii(oAuth2User.getName());
+	public void deleteUser(CustomUserDetails oAuth2User) {
+		User userEntity = oAuth2User.getUser();
 
 		userEntity.updateBuilder()
 			.isActive(false)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ spring:
             user-name-attribute: id
   mvc:
     dispatch-options-request: true
+
 logging:
   level:
     org.springframework.web: DEBUG

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -16,7 +16,7 @@
         <div class="menu-item" th:each="menu, iterStat : ${subMenus}">
             <span th:text="${menu.title}"></span>
             <!-- 서브메뉴 -->
-            <div class="submenu">
+            <div class="submenu" th:if="${menu.items} != null">
                 <span class="submenu-item" th:each="item : ${menu.items}" th:text="${item}"></span>
             </div>
         </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,6 +5,8 @@
     <title>타임리프 레이아웃</title>
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/reset.css}">
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
 <body>
 <header>
@@ -56,5 +58,38 @@
         </div>
     </section>
 </main>
+<script>
+    $.ajaxSetup({
+        beforeSend: function (xhr) {
+            xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+        }
+    });
+
+    // 전역 AJAX 에러 핸들러
+    $(document).ajaxError(function (event, jqXHR) {
+        if (jqXHR.status === 403) {
+            Swal.fire({
+                title: '접근 제한',
+                text: '접근 권한이 없습니다.',
+                icon: 'error',
+                confirmButtonText: '확인',
+                confirmButtonColor: '#3085d6',
+                width: '360px'
+            });
+        }
+    });
+
+    // 사용 예시: AJAX 요청
+    function adminRequest() {
+        $.ajax({
+            url: '/admin/test',
+            type: 'GET',
+            success: function (response) {
+                // 성공 시 처리
+            }
+            // 실패 시에는 위의 전역 에러 핸들러가 처리함
+        });
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
- 현제 세션의 User 정보를 더 쉽게 받아올 수 있도록 수정
- index.html에서 submenu의 하위 item이 없을 때 박스를 표시하지 않도록 수정
- 존재하지 않는 페이지에 접근하려고 시도 시 홈으로 리다이렉션
- 접근 권한이 없을 경우 경고 메시지를 출력할 수 있는 예시를 index.html에 기입
- user의 등급을 변경할 수 있는 함수 추가